### PR TITLE
Work to allow basemap override and dynamic switching

### DIFF
--- a/js/indicia.functions.js
+++ b/js/indicia.functions.js
@@ -470,4 +470,29 @@ jQuery(document).ready(function ($) {
     $(e.currentTarget).parent('.media-info').hide();
     return false;
   });
+
+  //Tie the selection of the dynamic1 & dymanic2 checkboxes together 
+  //and make one of them invisible.
+  var dyn1 = $("input[value='dynamic1']");
+  var dyn2 = $("input[value='dynamic2']");
+  dyn2.parent().hide(); //Parent list item
+  dyn1.change(function() {
+    dyn2.attr('checked', this.checked);
+  })
+  dyn2.change(function() {
+    dyn1.attr('checked', this.checked);
+  })
+
+  //Hide the basemap selection options if the dynamic basemap layers override is used
+  //and this is *not* a verification form.
+  var basemapLayersOverride = false;
+  var iformCategory = "";
+  try {
+    basemapLayersOverride = Drupal.settings.iform_user_ui_options.basemap_layers_override;
+    iformCategory = $("#form-category-picker option:selected").val();
+  } catch {
+  }
+  if (iformCategory != "Verification" && basemapLayersOverride) {
+    $('#ctrl-wrap-preset_layers').hide();
+  }
 });


### PR DESCRIPTION
I updated jquery.IndiciaMapPanel.js to create the two new layers - dynamic1 and dynamic2. Dynamic1, for now, is actually an OSM layer (because I can't get OS to work on my setup) but needs changing to OS and testing before deployment. Dynamic2 is a Google Satellite layer.

I added a handler registered to the 'zoomend' event to switch between the two dynamic layers using OL setBaseLayer function. The zoom threshold at which the layers switch is currently hard-coded here. This is also responsible for switching the visibility of the layers' option controls on the OL layer switcher control so that it appears to the user as if there is only one layer. (I'm unsure about whether or not I have included this function in the best place for it.)

I updated indicia.functions.js to include code responsible for a couple of things. I'm not sure if this is the best place for this code. I wondered about having it in a separate JS file, but I was unsure of the mechanism for doing that and including the code.

First thing is to tie the two edit form options for the map base layers dynamic1 and dynamic2 together - so that if one is checked or unchecked, then the other is forced to match. I also decided to make one of these invisible as I thought it would be less confusing to the user.

Second thing was to look for the Drupal JS variable Drupal.settings.iform_user_ui_options.basemap_layers_override to hide the basemap options completely if it is set. I also test to see if this is a verification form and don't hide if it is, regardless of the whether or not the basemap override was applied.
