### PR TITLE
Feature maps 2

### DIFF
--- a/js/jquery.indiciaMapPanel.js
+++ b/js/jquery.indiciaMapPanel.js
@@ -2509,6 +2509,7 @@ var destroyAllFeatures;
       //Is this the best place to add this event handler?
       //Handle the automatic switching between layers for the dynamic layer.
       div.map.events.register('zoomend', null, function() {
+        console.log("handler fired");
         var thisZoomLevel = div.map.getZoom();
         var visLayers = div.map.getLayersBy('visibility', true);
         var l;
@@ -2516,6 +2517,9 @@ var destroyAllFeatures;
         var i;
         var offLayer;
         var onLayer;
+        var lyrsForShownInputs = [];
+        var lyrsForHiddenInputs = []; 
+
         // Careful about recursion.
         if (indiciaData.settingBaseLayer) {
           return;
@@ -2539,15 +2543,58 @@ var destroyAllFeatures;
         if (onLayer && offLayer) {
           ///Adjust layer switcher control layer visibility regardless
           // of whether or not one of the layers selected.
-          var offInput = $('input[value="' + offLayer.name + '"]');
-          var onInput = $('input[value="' + onLayer.name + '"]');
-          offInput.hide(); //radio
-          offInput.next().hide(); //label
-          offInput.next().next().hide(); //br tag
+          lyrsForShownInputs.push(onLayer.id);
+          lyrsForHiddenInputs.push(offLayer.id);
+          
+          // var offInput = $('input[value="' + offLayer.name + '"]');
+          // var onInput = $('input[value="' + onLayer.name + '"]');
+          // offInput.hide(); //radio
+          // offInput.next().hide(); //label
+          // offInput.next().next().hide(); //br tag
+          // onInput.show(); //radio
+          // onInput.next().show(); //label
+          // onInput.next().next().show(); //br tag*/
+        }
+
+        visLayerIds = visLayers.map(function(l) {
+          return l.id;
+        })
+
+        for (i = 0; i < div.map.layers.length; i++) {
+          var l = div.map.layers[i];
+
+          if (l.zoomOutLayerId && lyrsForShownInputs.concat(lyrsForHiddenInputs).indexOf(l.id) == -1) {
+            //The layer has a corresponding zoomout layer and is not already accounted for 
+            var inId = l.id;
+            var outId = div.map.getLayersBy("layerId", l.zoomOutLayerId)[0].id;
+
+            if (visLayerIds.indexOf(inId) == -1 && visLayerIds.indexOf(outId) == -1) {
+              //Neither in or out layer is displayed, so only display control for out layer.
+              lyrsForShownInputs.push(outId);
+              lyrsForHiddenInputs.push(inId);
+            } else if (visLayerIds.indexOf(inId) > -1) {
+              lyrsForShownInputs.push(inId);
+              lyrsForHiddenInputs.push(outId);
+            } else {
+              lyrsForShownInputs.push(outId);
+              lyrsForHiddenInputs.push(inId);
+            }
+          }
+        }
+
+        lyrsForShownInputs.forEach(function(id) {
+          console.log("id", id)
+          var onInput = $('input[value="' + div.map.getLayer(id).name + '"]');
           onInput.show(); //radio
           onInput.next().show(); //label
           onInput.next().next().show(); //br tag*/
-        }
+        })
+        lyrsForHiddenInputs.forEach(function(id) {
+          var offInput = $('input[value="' + div.map.getLayer(id).name + '"]');
+          offInput.hide(); //radio
+          offInput.next().hide(); //label
+          offInput.next().next().hide(); //br tag
+        })
       })
 
       // Convert indicia WMS/WFS layers into js objects

--- a/js/jquery.indiciaMapPanel.js
+++ b/js/jquery.indiciaMapPanel.js
@@ -2509,7 +2509,6 @@ var destroyAllFeatures;
       //Is this the best place to add this event handler?
       //Handle the automatic switching between layers for the dynamic layer.
       div.map.events.register('zoomend', null, function() {
-        console.log("handler fired");
         var thisZoomLevel = div.map.getZoom();
         var visLayers = div.map.getLayersBy('visibility', true);
         var l;
@@ -2545,15 +2544,6 @@ var destroyAllFeatures;
           // of whether or not one of the layers selected.
           lyrsForShownInputs.push(onLayer.id);
           lyrsForHiddenInputs.push(offLayer.id);
-          
-          // var offInput = $('input[value="' + offLayer.name + '"]');
-          // var onInput = $('input[value="' + onLayer.name + '"]');
-          // offInput.hide(); //radio
-          // offInput.next().hide(); //label
-          // offInput.next().next().hide(); //br tag
-          // onInput.show(); //radio
-          // onInput.next().show(); //label
-          // onInput.next().next().show(); //br tag*/
         }
 
         visLayerIds = visLayers.map(function(l) {
@@ -2573,9 +2563,11 @@ var destroyAllFeatures;
               lyrsForShownInputs.push(outId);
               lyrsForHiddenInputs.push(inId);
             } else if (visLayerIds.indexOf(inId) > -1) {
+              //In layer is displayed
               lyrsForShownInputs.push(inId);
               lyrsForHiddenInputs.push(outId);
             } else {
+              //Out layer is displayed
               lyrsForShownInputs.push(outId);
               lyrsForHiddenInputs.push(inId);
             }
@@ -2583,7 +2575,6 @@ var destroyAllFeatures;
         }
 
         lyrsForShownInputs.forEach(function(id) {
-          console.log("id", id)
           var onInput = $('input[value="' + div.map.getLayer(id).name + '"]');
           onInput.show(); //radio
           onInput.next().show(); //label


### PR DESCRIPTION
I tested this and found a problem - when I had the dynamic layer selected and zoomed in and then changed to a non-dynamic layer, then both dynamic layers appeared in OL layer switcher control. This is because the part of the zoom-end handler (which gets fired when the layer is changed) that is responsible for hiding one of the dynamic layers was being bypassed if a non-dynamic layer was selected.

I noticed how you have generalised the ability to add dynamic layers which is really cool. That means that potentially, there could be several sets of dynamic layers, so the fix to make sure that only one layer in each pair of dynamic layers is visible in the switcher was a little more involved than otherwise would have been the case. So I've done it but I've put it in this pull request for you to review.

There is also another slight problem which I haven't addressed which is that because the two dynamic layers in the pair which we have defined aren't defined next to each other in the code, then if another layer is shown for the map that comes between them in the layer definition, then the ordering of the layers appears to change (in the switcher control) as the two dynamic layers switch. You can see this by having your iForm use the dynamic layer pair and, for example,  OS Leisure, which comes between them. Then you will see the apparent order move in the switcher control as the dynamic layers switch. I didn't want to change this because I saw that you'd done quite a bit of work there and I might miss something.