### PR TITLE
Fix for iRecord issue 601 - inappropriate display of OS in Ireland

### DIFF
--- a/js/jquery.indiciaMapPanel.js
+++ b/js/jquery.indiciaMapPanel.js
@@ -1203,9 +1203,15 @@ var destroyAllFeatures;
               layerId: 'dynamicOSGoogleSat.1',
               dynamicLayerIndex: 1,
               explicitlyDisallowed: [
+                // This MBR covers the island of Ireland where OS Leisure
+                // only has the most basic of OS mapping - country outline -
+                // at smaller scales and nothing all all as you zoom in.
                 new OpenLayers.Bounds([-210000, 190000, 180000, 630000])
               ],
               explicitlyAllowed: [
+                // This MBR covers the southern end of the Kintyre peninsula
+                // in Scotland which falls within the large NBR for all of the
+                // island of Ireland.
                 new OpenLayers.Bounds([145000, 600000, 193000, 640000])
               ]
             }));
@@ -2343,20 +2349,20 @@ var destroyAllFeatures;
             return switchToBaseLayer(div, id, dynamicLayerIndex - 1);
           }
         }
-        //Don't switch layer if the viewport is contained by any 'explicitlyDisallowed'
-        //specified for the layer, *unless* it is also contained by any 'permittedDisplayAreas'
-        var allowed = true;
+        //Don't switch layer if the viewport is contained by any 'explicitlyDisallowed' MBRs
+        //specified for the layer, *unless* it is also contained by any 'explicitlyAllowed' MBRs
+        var inAllowed, inDisallowed;
+        if (lSwitch.explicitlyDisallowed) {
+          inDisallowed = lSwitch.explicitlyDisallowed.some(function(mbr){
+            return mbr.containsBounds(newMapExtent);
+          });
+        }
         if (lSwitch.explicitlyAllowed){
-          allowed = lSwitch.explicitlyAllowed.some(function(mbr){
+          inAllowed = lSwitch.explicitlyAllowed.some(function(mbr){
             return mbr.containsBounds(newMapExtent);
           });
         }
-        if (!allowed && lSwitch.explicitlyDisallowed) {
-          allowed = !lSwitch.explicitlyDisallowed.some(function(mbr){
-            return mbr.containsBounds(newMapExtent);
-          });
-        }
-        if (!allowed) {
+        if (inDisallowed && !inAllowed) {
           if (dynamicLayerIndex > 0) {
             return switchToBaseLayer(div, id, dynamicLayerIndex - 1);
           }

--- a/js/jquery.indiciaMapPanel.js
+++ b/js/jquery.indiciaMapPanel.js
@@ -1201,7 +1201,13 @@ var destroyAllFeatures;
               minZoom: 1,
               maxZoom: 11,
               layerId: 'dynamicOSGoogleSat.1',
-              dynamicLayerIndex: 1
+              dynamicLayerIndex: 1,
+              explicitlyDisallowed: [
+                new OpenLayers.Bounds([-210000, 190000, 180000, 630000])
+              ],
+              explicitlyAllowed: [
+                new OpenLayers.Bounds([145000, 600000, 193000, 640000])
+              ]
             }));
           },
           function dynamicOSGoogleSat3() {
@@ -2333,6 +2339,24 @@ var destroyAllFeatures;
         // Don't switch layer if the new layer can't display the whole
         // viewport.
         if (!lSwitch.maxExtent.containsBounds(newMapExtent)) {
+          if (dynamicLayerIndex > 0) {
+            return switchToBaseLayer(div, id, dynamicLayerIndex - 1);
+          }
+        }
+        //Don't switch layer if the viewport is contained by any 'explicitlyDisallowed'
+        //specified for the layer, *unless* it is also contained by any 'permittedDisplayAreas'
+        var allowed = true;
+        if (lSwitch.explicitlyAllowed){
+          allowed = lSwitch.explicitlyAllowed.some(function(mbr){
+            return mbr.containsBounds(newMapExtent);
+          });
+        }
+        if (!allowed && lSwitch.explicitlyDisallowed) {
+          allowed = !lSwitch.explicitlyDisallowed.some(function(mbr){
+            return mbr.containsBounds(newMapExtent);
+          });
+        }
+        if (!allowed) {
           if (dynamicLayerIndex > 0) {
             return switchToBaseLayer(div, id, dynamicLayerIndex - 1);
           }


### PR DESCRIPTION
This is the fix for iRecord issue 601 (https://github.com/BiologicalRecordsCentre/iRecord/issues/601). It turned out to be a little more involved than apparent at first glance (as usual). I tried the approach of disallowing switch if an MBR covering Ireland was visible on the map, but this disallowed switching too often - including where only a tiny bit of MBR was visible (and Ireland itself not even on the map). So I tried disallowing only if MBR completely contains map view and this worked much better. However MBR for Ireland also covers the tip of Kintyre - Scotland, so when zooming right in on that area suddenly the basemap would switch from OS to OSM. To accommodate that, I also allowed definition of MBRs within which layer switch should always be allowed - even if also within larger MBR where disallowed. Mutliple MBRs in each of these two classes can be defined on a layer - in two arrays called explicitlyDisallowed and explicitlyAllowed.