### PR TITLE
Fix for missing sub-sample polys on edit of records entered via multi-site form

### DIFF
--- a/js/controls/speciesmap_controls.js
+++ b/js/controls/speciesmap_controls.js
@@ -510,7 +510,7 @@ var control_speciesmap_addcontrols;
           var parser = new OpenLayers.Format.WKT();
           var feature;
           feature = parser.read($(block).find('[name$="sample\:geom"]').val()); // style is null
-          // TODO should convert from Indicia internal projection to map projection
+          feature.geometry.transform(div.indiciaProjection, div.map.projection);
           feature.attributes.subSampleIndex = id[1];
           feature.attributes.sRef = $(block).find('[name$="sample\:entered_sref"]').val();
           feature.attributes.count = $('[name$="\:sampleIDX"]')


### PR DESCRIPTION
This addresses issue: https://github.com/BiologicalRecordsCentre/iRecord/issues/619

Upon closer inspection the sub-sample GR squares were only missing when the OS layer was being displayed on entry to the form - whether selected from the standalone OS Leisure or via the dynamic layer. If the dynamic layer was selected and the zoom level was such that the Google Satellite layer was displayed on entry, the GR squares were displayed. So it seemed likely something to do with projection.

The squares were being created with geometry encoded to the internal Indicia sref regardless of the map displayed, so I fixed this. Interestingly, there was a TODO comment from three years ago anticipating this problem and saying the CRS should be converted! @johnvanbreda  there are a couple of other similar TODOs in there but I left alone since I haven't spent the time working out what happens in the section of code they are in, but you might want to take a look.