### PR TITLE
Update to dynamic zooming layer switching logic

### DIFF
--- a/js/jquery.indiciaMapPanel.js
+++ b/js/jquery.indiciaMapPanel.js
@@ -1217,6 +1217,7 @@ var destroyAllFeatures;
           function dynamicOSGoogleSat1() {
             return new OpenLayers.Layer.WMTS($.extend({}, osLeisureOptions, {
               name: 'Dynamic (OpenStreetMap > *Ordnance Survey Leisure* > Google Satellite)',
+              maxWidth: 500000,
               minZoom: 1,
               maxZoom: 11,
               layerId: 'dynamicOSGoogleSat.1',
@@ -1240,6 +1241,7 @@ var destroyAllFeatures;
               type: google.maps.MapTypeId.SATELLITE,
               numZoomLevels: 20,
               sphericalMercator: true,
+              maxWidth: 500,
               minZoom: 18,
               layerId: 'dynamicOSGoogleSat.2',
               dynamicLayerIndex: 2,
@@ -2444,13 +2446,24 @@ var destroyAllFeatures;
       }
       // If we need to switch dynamic layer because of the zoom, find the new
       // sub-layer's index.
-      if (baseLayer.maxZoom && thisZoomLevel > baseLayer.maxZoom) {
-        onLayerIdx = baseLayer.dynamicLayerIndex + 1;
-      } else if (baseLayer.minZoom && thisZoomLevel < baseLayer.minZoom) {
-        onLayerIdx = baseLayer.dynamicLayerIndex - 1;
-      } else {
-        onLayerIdx = baseLayer.dynamicLayerIndex;
-      }
+      var dynamicLayers = _getPresetLayers(div.settings)[baseLayerIdParts[0]];
+      var bb = div.map.getExtent().transform(div.map.projection, new OpenLayers.Projection("EPSG:27700"));
+      var mapWidth = bb.right - bb.left;
+      onLayerIdx = dynamicLayers.reduce(function(index, lyr, i) {
+        var mapLayer = lyr();
+        if (!mapLayer.maxWidth || mapWidth < mapLayer.maxWidth) {
+          return i;
+        } else {
+          return index;
+        }
+      }, 0)
+      // if (baseLayer.maxZoom && thisZoomLevel > baseLayer.maxZoom) {
+      //   onLayerIdx = baseLayer.dynamicLayerIndex + 1;
+      // } else if (baseLayer.minZoom && thisZoomLevel < baseLayer.minZoom) {
+      //   onLayerIdx = baseLayer.dynamicLayerIndex - 1;
+      // } else {
+      //   onLayerIdx = baseLayer.dynamicLayerIndex;
+      // }
       indiciaData.settingBaseLayer = true;
       try {
         // Ensure switch is immediate.


### PR DESCRIPTION
Updated to perform layer selection based on width of map rather than zoom level, which changes depending on map layer.

This addresses https://github.com/BiologicalRecordsCentre/iRecord/issues/629.

Dynamic map sub-layers updated to include a maxZoom property which specifies the width of the map, in metres, above which this layer should not be displayed. The logic will select highest resolution sub-layer (highest sub-layer index) that is allowed to be displayed at the current map extent (width in metres). 

I've left the previous method in - commented out - for now for comparison.