### PR TITLE
Fix problem where linked lists no longer seem to work.

### DIFF
--- a/js/indicia.functions.js
+++ b/js/indicia.functions.js
@@ -464,7 +464,7 @@ if (typeof window.indiciaData === 'undefined') {
     var childSelect = $('#' + options.escapedId);
     var parentSelect = $(el);
     if (parentSelect.val()) {
-      $.getJSON(options.request + '&query=' + options.query.replace('%22val%22', parentSelect.val()), function onResponse(data) {
+      $.getJSON(options.request + '&' + options.query.replace('"+$(this).val()+"', parentSelect.val()), function onResponse(data) {
         childSelect.find('option').remove();
         if (data.length > 0) {
           childSelect.removeClass('ui-state-disabled');


### PR DESCRIPTION
1. The query parameter was causing problems as the query has parameter names in it.

So we ended up with something like
&query=square_id=

removed query= so we get something like

&square_id=

2. Also I don't understand why the replacement for '%22val22%' was present, the new replacement seems to work and is based on this line from data_entry_helper inilinkedlists

$query = $options['filterField'] . '="+$(this).val()+"';