### PR TITLE
Iss 800 6

### DIFF
--- a/js/indicia.datacomponents/jquery.idc.filterSummary.js
+++ b/js/indicia.datacomponents/jquery.idc.filterSummary.js
@@ -1,0 +1,229 @@
+/**
+ * Indicia, the OPAL Online Recording Toolkit.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/gpl.html.
+ *
+ * @author Indicia Team
+ * @license http://www.gnu.org/licenses/gpl.html GPL 3.0
+ * @link https://github.com/indicia-team/client_helpers
+ */
+
+ /**
+ * Output plugin for filter summary.
+ */
+(function filterSummaryPlugin() {
+  'use strict';
+  var $ = jQuery;
+
+  indiciaFns.setFilterSummary = function(data) {
+
+    var filterDef, selector;
+    if (data) {
+      filterDef = JSON.parse(data[0].definition);
+      selector = '#filterSummary-' + data[0].id;
+    } else {
+      filterDef = indiciaData.filter.def;
+      selector = '#filterSummary-standard-params';
+    }
+    
+    var r = [];
+    indiciaData.filterParser.what.loadFilter(filterDef);
+    r.push(indiciaData.filterParser.what.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.when.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.where.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.who.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.occ_id.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.smp_id.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.quality.getDescription(filterDef, '</li><li>'));
+    r.push(indiciaData.filterParser.source.getDescription(filterDef, '</li><li>'));
+
+    // Filter out empty elements
+    r = r.filter(function(e) {if(e) return e;});
+
+    if (r.length) {
+      $(selector).html('<ul><li>' + r.join('</li><li>') + '</li></ul>');
+    } else {
+      if (selector === '#filterSummary-standard-params') {
+        $('#filterSummary-standard-params-header').hide();
+      }
+      
+    }
+  }
+
+  function addHtml(currentHtml, newHtml) {
+    return currentHtml ? currentHtml + newHtml : newHtml
+  }
+
+  /**
+   * Place to store public methods.
+   */
+  var methods;
+
+  /**
+   * Declare default settings.
+   */
+  var defaults = {
+
+  };
+
+  /**
+   * Declare public methods.
+   */
+  methods = {
+    /**
+     * Initialise the idcFilterSummary plugin.
+     *
+     * @param array options
+     */
+    init: function init(options) {
+      var el = this;
+      indiciaFns.registerOutputPluginClass('idcFilterSummary');
+      el.settings = $.extend({}, defaults);
+      // Apply settings passed in the HTML data-* attribute.
+      if (typeof $(el).attr('data-idc-config') !== 'undefined') {
+        $.extend(el.settings, JSON.parse($(el).attr('data-idc-config')));
+      }
+      // Apply settings passed to the constructor.
+      if (typeof options !== 'undefined') {
+        $.extend(el.settings, options);
+      }
+    },
+
+    /*
+     * Populate the idcFilterSummary.
+     */
+    populate: function populate() {
+      var el = $(this).find('.filter-summary-contents');
+      var html = '';
+      var functionCalls = [];
+
+      // permissionFilters control
+      if ($('.permissions-filter').length > 0) {
+        $.each($('.permissions-filter'), function eachPermissionFilter() {
+          if ($(this).val()) {
+            if ($(this).val().substr(0,1) === 'p' || $(this).val().substr(0,1) === 'g') {
+              // If the selected value starts with p, it is a general permissions filter and the
+              // text value of the control can just be output.
+              // If the selected value starts with g, it is a group filter and the
+              // text value of the control can just be output.
+              html = addHtml(html, '<div><b>Context:</b> ' + $(this).find('option:selected').text() + '</div>');
+            } else {
+              // The selected value specifies a permissions filter which needs parsing
+              var filterId = $(this).val().substr(2);
+              html = addHtml(html, '<div><b>' + $(this).find('option:selected').text() + ":</b></div>");
+              html = addHtml(html, '<div id="filterSummary-' + filterId + '"></div>');
+
+              functionCalls.push({
+                function: $.ajax,
+                arg: {
+                  dataType: 'json',
+                  url: indiciaData.read.url + 'index.php/services/data/filter/' + filterId,
+                  data: 'mode=json&view=list&auth_token=' + indiciaData.read.auth_token +
+                  '&nonce=' + indiciaData.read.nonce + '&callback=?',
+                  success: indiciaFns.setFilterSummary
+                }
+              })
+            }
+          }
+        });
+      }
+
+      // User filters drop down.
+      if ($('.user-filter').length > 0) {
+        $.each($('.user-filter'), function eachUserFilter() {
+          if ($(this).val()) {
+            // The value specifies a permissions filter which needs parsing
+            var filterId = $(this).val()
+            html = addHtml(html, '<div><b>' + $(this).find('option:selected').text() + ":</b></div>");
+            html = addHtml(html, '<div id="filterSummary-' + filterId + '"></div>');
+
+            functionCalls.push({
+              function: $.ajax,
+              arg: {
+                dataType: 'json',
+                url: indiciaData.read.url + 'index.php/services/data/filter/' + filterId,
+                data: 'mode=json&view=list&auth_token=' + indiciaData.read.auth_token +
+                '&nonce=' + indiciaData.read.nonce + '&callback=?',
+                success: indiciaFns.setFilterSummary
+              }
+            })
+          }
+        });
+      }
+
+      // Standard params.
+      if ($('#standard-params').length > 0) {
+        $.each($('#standard-params'), function eachStatusFilter() {
+
+          html = addHtml(html, '<div id="filterSummary-standard-params-header"></div>');
+          html = addHtml(html, '<div id="filterSummary-standard-params"></div>');
+          //indiciaFns.setFilterSummary();
+          functionCalls.push({
+            function: function() {
+              setTimeout(function() {
+                var title=$('#active-filter-label').text()
+                if (title) {
+                  $('#filterSummary-standard-params-header').html('<b>Standard filter (' + title + '):</b>') 
+                } else {
+                  $('#filterSummary-standard-params-header').html('<b>Standard filter:</b>') 
+                }
+              }, 100);
+              indiciaFns.setFilterSummary();
+            },
+            arg: null
+          })
+        });
+      }
+
+      // Status filters drop down.
+      if ($('.status-filters').length > 0) {
+        $.each($('.status-filters'), function eachStatusFilter() {
+          if ($(this).val()) {
+            // The value specifies a record status - display the text value of the selected option
+            html = addHtml(html, '<div><b>Status:</b> ' + $(this).find('option:selected').text() + '</div>');
+          }
+        });
+      }
+
+      $(el).html(html);
+      if (functionCalls.length) {
+         functionCalls.forEach(function(fc) {
+          fc.function(fc.arg);
+        });
+      }
+    }
+  };
+
+  /**
+   * Extend jQuery to declare idcFilterSummary method.
+   */
+  $.fn.idcFilterSummary = function buildFilterSummary(methodOrOptions) {
+
+    var passedArgs = arguments;
+    var result;
+    $.each(this, function callOnEachOutput() {
+      if (methods[methodOrOptions]) {
+        // Call a declared method.
+        result = methods[methodOrOptions].apply(this, Array.prototype.slice.call(passedArgs, 1));
+        return true;
+      } else if (typeof methodOrOptions === 'object' || !methodOrOptions) {
+        // Default to "init".
+        return methods.init.apply(this, passedArgs);
+      }
+      // If we get here, the wrong method was called.
+      $.error('Method ' + methodOrOptions + ' does not exist on jQuery.idcFilterSummary');
+      return true;
+    });
+    // If the method has no explicit response, return this to allow chaining.
+    return typeof result === 'undefined' ? this : result;
+  };
+}());

--- a/js/indicia.datacomponents/jquery.idc.filterSummary.js
+++ b/js/indicia.datacomponents/jquery.idc.filterSummary.js
@@ -166,7 +166,6 @@
 
           html = addHtml(html, '<div id="filterSummary-standard-params-header"></div>');
           html = addHtml(html, '<div id="filterSummary-standard-params"></div>');
-          //indiciaFns.setFilterSummary();
           functionCalls.push({
             function: function() {
               setTimeout(function() {

--- a/js/reportFilters.js
+++ b/js/reportFilters.js
@@ -124,7 +124,7 @@ jQuery(document).ready(function ($) {
     return $('input[name="location_list[]"]').length > 0 || ($('#imp-sref').val() !== '' && $('#imp-sref').val() !== null);
   }
 
-  // functions that are required both by the panObjList (below) and elsewhere.
+  // filterParser functions that are required globally.
   indiciaData.filterParser = {
     what: {
       loadFilter: function (filterDef) {
@@ -373,102 +373,6 @@ jQuery(document).ready(function ($) {
   // functions that drive each of the filter panes, e.g. to obtain the description from the controls.
   var paneObjList = {
     what: {
-      loadFilter: function () {
-        indiciaData.filterParser.what.loadFilter(indiciaData.filter.def);
-        // // Cleanup if still refers to defunct higher_taxa_taxon_list_list.
-        // if (typeof indiciaData.filter.def.higher_taxa_taxon_list_list !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_list !== '') {
-        //   indiciaData.filter.def.taxa_taxon_list_list = indiciaData.filter.def.higher_taxa_taxon_list_list;
-        //   if (typeof indiciaData.filter.def.higher_taxa_taxon_list_names !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_names !== '') {
-        //     indiciaData.filter.def.taxa_taxon_list_names = indiciaData.filter.def.higher_taxa_taxon_list_names;
-        //   }
-        // }
-        // delete indiciaData.filter.def.higher_taxa_taxon_list_list;
-        // delete indiciaData.filter.def.higher_taxa_taxon_list_names;
-        // // if list of ids defined but not group names, this is a taxon group list loaded from the user profile.
-        // // Hijack the names from indiciaData.myGroups.
-        // if (typeof indiciaData.filter.def.taxon_group_list !== 'undefined' && typeof indiciaData.filter.def.taxon_group_names === 'undefined') {
-        //   indiciaData.filter.def.taxon_group_names = [];
-        //   var foundIds = [], foundNames = [];
-        //   // Loop the group IDs we are expected to load
-        //   $.each(indiciaData.filter.def.taxon_group_list, function (idx, groupId) {
-        //     // Use the myGroups list to look them up
-        //     $.each(indiciaData.myGroups, function () {
-        //       if (this[0] === parseInt(groupId)) {
-        //         foundIds.push(this[0]);
-        //         foundNames.push(this[1]);
-        //       }
-        //     });
-        //   });
-        //   indiciaData.filter.def.taxon_group_names = foundNames;
-        //   indiciaData.filter.def.taxon_group_list = foundIds;
-        // }
-      },
-      getDescription: function () {
-        return indiciaData.filterParser.what.getDescription(indiciaData.filter.def, '<br/>');
-        // var groups = [];
-        // var taxa = [];
-        // var designations = [];
-        // var r = [];
-        // var filterDef = indiciaData.filter.def;
-        // if (filterDef.taxon_group_list && filterDef.taxon_group_names) {
-        //   $.each(filterDef.taxon_group_names, function (idx, group) {
-        //     groups.push(group);
-        //   });
-        // }
-        // if (filterDef.taxa_taxon_list_list && filterDef.taxa_taxon_list_names) {
-        //   $.each(filterDef.taxa_taxon_list_names, function (idx, taxon) {
-        //     taxa.push(taxon);
-        //   });
-        // }
-        // if (filterDef.taxon_designation_list && filterDef.taxon_designation_list_names) {
-        //   $.each(filterDef.taxon_designation_list_names, function (idx, designation) {
-        //     designations.push(designation);
-        //   });
-        // }
-        // if (groups.length > 0) {
-        //   r.push(groups.join(', '));
-        // }
-        // if (taxa.length > 0) {
-        //   r.push(taxa.join(', '));
-        // }
-        // if (designations.length > 0) {
-        //   r.push(designations.join(', '));
-        // }
-        // if (filterDef.taxon_rank_sort_order_combined) {
-        //   r.push($('#level-label').text() + ' ' + $('#taxon_rank_sort_order_op').find('option:selected').text() + ' ' +
-        //     $('#taxon_rank_sort_order_combined').find('option:selected').text());
-        // }
-        // if (filterDef.marine_flag && indiciaData.filter.def.marine_flag !== 'all') {
-        //   r.push($('#marine_flag').find('option[value=' + filterDef.marine_flag + ']').text());
-        // }
-        // if (typeof filterDef.confidential !== 'undefined') {
-        //   switch (filterDef.confidential) {
-        //     case 't':
-        //       r.push(indiciaData.lang.reportFilters.OnlyConfidentialRecords);
-        //       break;
-        //     case 'all':
-        //       r.push(indiciaData.lang.reportFilters.AllConfidentialRecords);
-        //       break;
-        //     default:
-        //       r.push(indiciaData.lang.reportFilters.NoConfidentialRecords);
-        //   }
-        // }
-        // if (typeof filterDef.release_status !== 'undefined') {
-        //   switch (filterDef.release_status) {
-        //     case 'A':
-        //       r.push(indiciaData.lang.reportFilters.includeUnreleasedRecords);
-        //       break;
-        //     default:
-        //       r.push(indiciaData.lang.reportFilters.excludeUnreleasedRecords);
-        //   }
-        // }
-        // if (typeof filterDef.taxa_taxon_list_attribute_term_descriptions !== 'undefined') {
-        //   $.each(filterDef.taxa_taxon_list_attribute_term_descriptions, function getAttrDescription(label, terms) {
-        //     r.push(label + ' ' + Object.values(terms).join(', '));
-        //   });
-        // }
-        // return r.join('<br/>');
-      },
       applyFormToDefinition: function () {
         var ttlAttrTermIds = [];
         var ttlAttrTermDescriptions = {};
@@ -619,34 +523,6 @@ jQuery(document).ready(function ($) {
       }
     },
     when: {
-      getDescription: function () {
-        return indiciaData.filterParser.when.getDescription(indiciaData.filter.def, '<br/>');
-        // var r = [];
-        // var dateType = 'recorded';
-        // var dateFromField = 'date_from';
-        // var dateToField = 'date_to';
-        // var dateAgeField = 'date_age';
-        // if (typeof indiciaData.filter.def.date_type !== 'undefined') {
-        //   dateType = indiciaData.filter.def.date_type;
-        //   if (dateType !== 'recorded') {
-        //     dateFromField = dateType + '_date_from';
-        //     dateToField = dateType + '_date_to';
-        //     dateAgeField = dateType + '_date_age';
-        //   }
-        // }
-        // if (indiciaData.filter.def[dateFromField] && indiciaData.filter.def[dateToField]) {
-        //   r.push('Records ' + dateType + ' between ' + indiciaData.filter.def[dateFromField] + ' and ' +
-        //     indiciaData.filter.def[dateToField]);
-        // } else if (indiciaData.filter.def[dateFromField]) {
-        //   r.push('Records ' + dateType + ' on or after ' + indiciaData.filter.def[dateFromField]);
-        // } else if (indiciaData.filter.def[dateToField]) {
-        //   r.push('Records ' + dateType + ' on or before ' + indiciaData.filter.def[dateToField]);
-        // }
-        // if (indiciaData.filter.def[dateAgeField]) {
-        //   r.push('Records ' + dateType + ' in last ' + indiciaData.filter.def[dateAgeField]);
-        // }
-        // return r.join('<br/>');
-      },
       loadForm: function (context) {
         var dateTypePrefix = '';
         if (typeof indiciaData.filter.def.date_type !== 'undefined' && indiciaData.filter.def.date_type !== 'recorded') {
@@ -701,25 +577,6 @@ jQuery(document).ready(function ($) {
       }
     },
     where: {
-      getDescription: function () {
-        return indiciaData.filterParser.where.getDescription(indiciaData.filter.def);
-        // if (indiciaData.filter.def.remembered_location_name) {
-        //   return 'Records in ' + indiciaData.filter.def.remembered_location_name;
-        // } else if (indiciaData.filter.def['imp-location:name']) { // legacy
-        //   return 'Records in ' + indiciaData.filter.def['imp-location:name'];
-        // } else if (indiciaData.filter.def.indexed_location_id) {
-        //   // legacy location ID for the user's locality. In this case we need to hijack the site type drop down shortcuts to get the locality name
-        //   return $('#site-type option[value=loc\\:' + indiciaData.filter.def.indexed_location_id + ']').text();
-        // } else if (indiciaData.filter.def.location_name) {
-        //   return 'Records in places containing "' + indiciaData.filter.def.location_name + '"';
-        // } else if (indiciaData.filter.def.sref) {
-        //   return 'Records in square ' + indiciaData.filter.def.sref;
-        // } else if (indiciaData.filter.def.searchArea) {
-        //   return 'Records within a freehand boundary';
-        // } else {
-        //   return '';
-        // }
-      },
       applyFormToDefinition: function () {
         var geoms = [];
         var geom;
@@ -892,14 +749,6 @@ jQuery(document).ready(function ($) {
       }
     },
     who: {
-      getDescription: function () {
-        return indiciaData.filterParser.who.getDescription(indiciaData.filter.def);
-        // if (indiciaData.filter.def.my_records) {
-        //   return indiciaData.lang.reportFilters.MyRecords;
-        // } else {
-        //   return '';
-        // }
-      },
       loadForm: function (context) {
         if (context && context.my_records) {
           $('#my_records').prop('disabled', true);
@@ -912,72 +761,14 @@ jQuery(document).ready(function ($) {
       }
     },
     occ_id: {
-      getDescription: function () {
-        return indiciaData.filterParser.occ_id.getDescription(indiciaData.filter.def);
-        // var op;
-        // if (indiciaData.filter.def.occ_id) {
-        //   op = typeof indiciaData.filter.def.occ_id_op === 'undefined' ?
-        //     '=' : indiciaData.filter.def.occ_id_op.replace(/[<=>]/g, '\\$&');
-        //   return $('#occ_id_op').find("option[value='" + op + "']").html()
-        //     + ' ' + indiciaData.filter.def.occ_id;
-        // }
-        // else if (indiciaData.filter.def.occurrence_external_key) {
-        //   return $('#ctrl-wrap-occurrence_external_key label').html().replace(/:$/, '')
-        //     + ' ' + indiciaData.filter.def.occurrence_external_key;
-        // }
-        // return '';
-      },
       loadForm: function () {
       }
     },
     smp_id: {
-      getDescription: function () {
-        return indiciaData.filterParser.smp_id.getDescription(indiciaData.filter.def);
-        // var op;
-        // if (indiciaData.filter.def.smp_id) {
-        //   op = typeof indiciaData.filter.def.smp_id === 'undefined' ? '=' : indiciaData.filter.def.smp_id.replace(/[<=>]/g, "\\$&");
-        //   return $('#smp_id_op option[value=' + op + ']').html()
-        //     + ' ' + indiciaData.filter.def.smp_id;
-        // }
-        // return '';
-      },
       loadForm: function () {
       }
     },
     quality: {
-      getDescription: function () {
-        return indiciaData.filterParser.quality.getDescription(indiciaData.filter.def, '<br/>');
-        // var r = [];
-        // var op;
-        // var quality;
-        // if (typeof indiciaData.filter.def.quality === 'undefined') {
-        //   quality = 'all';
-        // } else {
-        //   quality = typeof indiciaData.filter.def.quality === 'string'
-        //     ? indiciaData.filter.def.quality : indiciaData.filter.def.quality.toString();
-        // }
-        // if (quality !== 'all') {
-        //   r.push($('#quality-filter option[value=' + quality.replace('!', '\\!') + ']').html());
-        // }
-        // if (indiciaData.filter.def.autochecks === 'F') {
-        //   r.push(indiciaData.lang.reportFilters.AutochecksFailed);
-        // } else if (indiciaData.filter.def.autochecks === 'P') {
-        //   r.push(indiciaData.lang.reportFilters.AutochecksPassed);
-        // }
-        // if (indiciaData.filter.def.identification_difficulty) {
-        //   op = typeof indiciaData.filter.def.identification_difficulty_op === 'undefined' ?
-        //     '=' : indiciaData.filter.def.identification_difficulty_op.replace(/[<=>]/g, '\\$&');
-        //   r.push(indiciaData.lang.reportFilters.IdentificationDifficulty + ' ' +
-        //     $('#identification_difficulty_op').find("option[value='" + op + "']").html() +
-        //     ' ' + indiciaData.filter.def.identification_difficulty);
-        // }
-        // if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '1') {
-        //   r.push(indiciaData.lang.reportFilters.HasPhotos);
-        // } else if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '0') {
-        //   r.push(indiciaData.lang.reportFilters.HasNoPhotos);
-        // }
-        // return r.join('<br/>');
-      },
       loadForm: function (context) {
         if (context && context.quality && context.quality !== 'all') {
           $('#quality-filter').prop('disabled', true);
@@ -1008,33 +799,6 @@ jQuery(document).ready(function ($) {
       }
     },
     source: {
-      getDescription: function () {
-        return indiciaData.filterParser.source.getDescription(indiciaData.filter.def, '<br/>');
-        // var r = [];
-        // var list = [];
-        // var paramValue;
-        // if (indiciaData.filter.def.input_form_list) {
-        //   $.each(indiciaData.filter.def.input_form_list.split(','), function (idx, id) {
-        //     list.push($('#check-form-' + indiciaData.formsList[id.replace(/'/g, '')]).next('label').html());
-        //   });
-        //   r.push((indiciaData.filter.def.input_form_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        // } else if (indiciaData.filter.def.survey_list) {
-        //   paramValue = typeof indiciaData.filter.def.survey_list === 'string'
-        //     ? indiciaData.filter.def.survey_list.split(',') : [indiciaData.filter.def.survey_list ];
-        //   $.each(paramValue, function (idx, id) {
-        //     list.push($('#check-survey-' + id).next('label').html());
-        //   });
-        //   r.push((indiciaData.filter.def.survey_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        // } else if (indiciaData.filter.def.website_list) {
-        //   paramValue = typeof indiciaData.filter.def.website_list === 'string'
-        //     ? indiciaData.filter.def.website_list.split(',') : [indiciaData.filter.def.survey_list ];
-        //   $.each(indiciaData.filter.def.website_list.toString().split(','), function (idx, id) {
-        //     list.push($('#check-website-' + id).next('label').html());
-        //   });
-        //   r.push((indiciaData.filter.def.website_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        // }
-        // return r.join('<br/>');
-      },
       loadForm: function (context) {
         if (context && ((context.website_list && context.website_list_op) ||
           (context.survey_list && context.survey_list_op) || (context.input_form_list && context.input_form_list_op))) {
@@ -1425,7 +1189,7 @@ jQuery(document).ready(function ($) {
     var name;
     $.each($('#filter-panes .pane'), function (idx, pane) {
       name = pane.id.replace(/^pane-filter_/, '');
-      description = paneObjList[name].getDescription();
+      description = indiciaData.filterParser[name].getDescription(indiciaData.filter.def, '<br/>');
       if (description === '') {
         description = indiciaData.lang.reportFiltersNoDescription[name];
       }
@@ -1452,8 +1216,8 @@ jQuery(document).ready(function ($) {
     $('#active-filter-label').html('Active filter: ' + data[0].title);
     $.each($('#filter-panes .pane'), function (idx, pane) {
       var name = pane.id.replace(/^pane-filter_/, '');
-      if (paneObjList[name].loadFilter) {
-        paneObjList[name].loadFilter();
+      if (indiciaData.filterParser[name].loadFilter) {
+        indiciaData.filterParser[name].loadFilter(indiciaData.filter.def);
       }
     });
     indiciaFns.updateFilterDescriptions();
@@ -1703,8 +1467,8 @@ jQuery(document).ready(function ($) {
 
   $('#filter-build').click(function () {
     var desc;
-    $.each(paneObjList, function (name, obj) {
-      desc = obj.getDescription();
+    $.each(indiciaData.filterParser, function (name, obj) {
+      desc = obj.getDescription(indiciaData.filter.def, '<br/>');
       if (desc === '') {
         desc = indiciaData.lang.reportFiltersNoDescription[name];
       }

--- a/js/reportFilters.js
+++ b/js/reportFilters.js
@@ -374,98 +374,100 @@ jQuery(document).ready(function ($) {
   var paneObjList = {
     what: {
       loadFilter: function () {
-        // Cleanup if still refers to defunct higher_taxa_taxon_list_list.
-        if (typeof indiciaData.filter.def.higher_taxa_taxon_list_list !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_list !== '') {
-          indiciaData.filter.def.taxa_taxon_list_list = indiciaData.filter.def.higher_taxa_taxon_list_list;
-          if (typeof indiciaData.filter.def.higher_taxa_taxon_list_names !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_names !== '') {
-            indiciaData.filter.def.taxa_taxon_list_names = indiciaData.filter.def.higher_taxa_taxon_list_names;
-          }
-        }
-        delete indiciaData.filter.def.higher_taxa_taxon_list_list;
-        delete indiciaData.filter.def.higher_taxa_taxon_list_names;
-        // if list of ids defined but not group names, this is a taxon group list loaded from the user profile.
-        // Hijack the names from indiciaData.myGroups.
-        if (typeof indiciaData.filter.def.taxon_group_list !== 'undefined' && typeof indiciaData.filter.def.taxon_group_names === 'undefined') {
-          indiciaData.filter.def.taxon_group_names = [];
-          var foundIds = [], foundNames = [];
-          // Loop the group IDs we are expected to load
-          $.each(indiciaData.filter.def.taxon_group_list, function (idx, groupId) {
-            // Use the myGroups list to look them up
-            $.each(indiciaData.myGroups, function () {
-              if (this[0] === parseInt(groupId)) {
-                foundIds.push(this[0]);
-                foundNames.push(this[1]);
-              }
-            });
-          });
-          indiciaData.filter.def.taxon_group_names = foundNames;
-          indiciaData.filter.def.taxon_group_list = foundIds;
-        }
+        indiciaData.filterParser.what.loadFilter(indiciaData.filter.def);
+        // // Cleanup if still refers to defunct higher_taxa_taxon_list_list.
+        // if (typeof indiciaData.filter.def.higher_taxa_taxon_list_list !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_list !== '') {
+        //   indiciaData.filter.def.taxa_taxon_list_list = indiciaData.filter.def.higher_taxa_taxon_list_list;
+        //   if (typeof indiciaData.filter.def.higher_taxa_taxon_list_names !== 'undefined' && indiciaData.filter.def.higher_taxa_taxon_list_names !== '') {
+        //     indiciaData.filter.def.taxa_taxon_list_names = indiciaData.filter.def.higher_taxa_taxon_list_names;
+        //   }
+        // }
+        // delete indiciaData.filter.def.higher_taxa_taxon_list_list;
+        // delete indiciaData.filter.def.higher_taxa_taxon_list_names;
+        // // if list of ids defined but not group names, this is a taxon group list loaded from the user profile.
+        // // Hijack the names from indiciaData.myGroups.
+        // if (typeof indiciaData.filter.def.taxon_group_list !== 'undefined' && typeof indiciaData.filter.def.taxon_group_names === 'undefined') {
+        //   indiciaData.filter.def.taxon_group_names = [];
+        //   var foundIds = [], foundNames = [];
+        //   // Loop the group IDs we are expected to load
+        //   $.each(indiciaData.filter.def.taxon_group_list, function (idx, groupId) {
+        //     // Use the myGroups list to look them up
+        //     $.each(indiciaData.myGroups, function () {
+        //       if (this[0] === parseInt(groupId)) {
+        //         foundIds.push(this[0]);
+        //         foundNames.push(this[1]);
+        //       }
+        //     });
+        //   });
+        //   indiciaData.filter.def.taxon_group_names = foundNames;
+        //   indiciaData.filter.def.taxon_group_list = foundIds;
+        // }
       },
       getDescription: function () {
-        var groups = [];
-        var taxa = [];
-        var designations = [];
-        var r = [];
-        var filterDef = indiciaData.filter.def;
-        if (filterDef.taxon_group_list && filterDef.taxon_group_names) {
-          $.each(filterDef.taxon_group_names, function (idx, group) {
-            groups.push(group);
-          });
-        }
-        if (filterDef.taxa_taxon_list_list && filterDef.taxa_taxon_list_names) {
-          $.each(filterDef.taxa_taxon_list_names, function (idx, taxon) {
-            taxa.push(taxon);
-          });
-        }
-        if (filterDef.taxon_designation_list && filterDef.taxon_designation_list_names) {
-          $.each(filterDef.taxon_designation_list_names, function (idx, designation) {
-            designations.push(designation);
-          });
-        }
-        if (groups.length > 0) {
-          r.push(groups.join(', '));
-        }
-        if (taxa.length > 0) {
-          r.push(taxa.join(', '));
-        }
-        if (designations.length > 0) {
-          r.push(designations.join(', '));
-        }
-        if (filterDef.taxon_rank_sort_order_combined) {
-          r.push($('#level-label').text() + ' ' + $('#taxon_rank_sort_order_op').find('option:selected').text() + ' ' +
-            $('#taxon_rank_sort_order_combined').find('option:selected').text());
-        }
-        if (filterDef.marine_flag && indiciaData.filter.def.marine_flag !== 'all') {
-          r.push($('#marine_flag').find('option[value=' + filterDef.marine_flag + ']').text());
-        }
-        if (typeof filterDef.confidential !== 'undefined') {
-          switch (filterDef.confidential) {
-            case 't':
-              r.push(indiciaData.lang.reportFilters.OnlyConfidentialRecords);
-              break;
-            case 'all':
-              r.push(indiciaData.lang.reportFilters.AllConfidentialRecords);
-              break;
-            default:
-              r.push(indiciaData.lang.reportFilters.NoConfidentialRecords);
-          }
-        }
-        if (typeof filterDef.release_status !== 'undefined') {
-          switch (filterDef.release_status) {
-            case 'A':
-              r.push(indiciaData.lang.reportFilters.includeUnreleasedRecords);
-              break;
-            default:
-              r.push(indiciaData.lang.reportFilters.excludeUnreleasedRecords);
-          }
-        }
-        if (typeof filterDef.taxa_taxon_list_attribute_term_descriptions !== 'undefined') {
-          $.each(filterDef.taxa_taxon_list_attribute_term_descriptions, function getAttrDescription(label, terms) {
-            r.push(label + ' ' + Object.values(terms).join(', '));
-          });
-        }
-        return r.join('<br/>');
+        return indiciaData.filterParser.what.getDescription(indiciaData.filter.def, '<br/>');
+        // var groups = [];
+        // var taxa = [];
+        // var designations = [];
+        // var r = [];
+        // var filterDef = indiciaData.filter.def;
+        // if (filterDef.taxon_group_list && filterDef.taxon_group_names) {
+        //   $.each(filterDef.taxon_group_names, function (idx, group) {
+        //     groups.push(group);
+        //   });
+        // }
+        // if (filterDef.taxa_taxon_list_list && filterDef.taxa_taxon_list_names) {
+        //   $.each(filterDef.taxa_taxon_list_names, function (idx, taxon) {
+        //     taxa.push(taxon);
+        //   });
+        // }
+        // if (filterDef.taxon_designation_list && filterDef.taxon_designation_list_names) {
+        //   $.each(filterDef.taxon_designation_list_names, function (idx, designation) {
+        //     designations.push(designation);
+        //   });
+        // }
+        // if (groups.length > 0) {
+        //   r.push(groups.join(', '));
+        // }
+        // if (taxa.length > 0) {
+        //   r.push(taxa.join(', '));
+        // }
+        // if (designations.length > 0) {
+        //   r.push(designations.join(', '));
+        // }
+        // if (filterDef.taxon_rank_sort_order_combined) {
+        //   r.push($('#level-label').text() + ' ' + $('#taxon_rank_sort_order_op').find('option:selected').text() + ' ' +
+        //     $('#taxon_rank_sort_order_combined').find('option:selected').text());
+        // }
+        // if (filterDef.marine_flag && indiciaData.filter.def.marine_flag !== 'all') {
+        //   r.push($('#marine_flag').find('option[value=' + filterDef.marine_flag + ']').text());
+        // }
+        // if (typeof filterDef.confidential !== 'undefined') {
+        //   switch (filterDef.confidential) {
+        //     case 't':
+        //       r.push(indiciaData.lang.reportFilters.OnlyConfidentialRecords);
+        //       break;
+        //     case 'all':
+        //       r.push(indiciaData.lang.reportFilters.AllConfidentialRecords);
+        //       break;
+        //     default:
+        //       r.push(indiciaData.lang.reportFilters.NoConfidentialRecords);
+        //   }
+        // }
+        // if (typeof filterDef.release_status !== 'undefined') {
+        //   switch (filterDef.release_status) {
+        //     case 'A':
+        //       r.push(indiciaData.lang.reportFilters.includeUnreleasedRecords);
+        //       break;
+        //     default:
+        //       r.push(indiciaData.lang.reportFilters.excludeUnreleasedRecords);
+        //   }
+        // }
+        // if (typeof filterDef.taxa_taxon_list_attribute_term_descriptions !== 'undefined') {
+        //   $.each(filterDef.taxa_taxon_list_attribute_term_descriptions, function getAttrDescription(label, terms) {
+        //     r.push(label + ' ' + Object.values(terms).join(', '));
+        //   });
+        // }
+        // return r.join('<br/>');
       },
       applyFormToDefinition: function () {
         var ttlAttrTermIds = [];
@@ -618,31 +620,32 @@ jQuery(document).ready(function ($) {
     },
     when: {
       getDescription: function () {
-        var r = [];
-        var dateType = 'recorded';
-        var dateFromField = 'date_from';
-        var dateToField = 'date_to';
-        var dateAgeField = 'date_age';
-        if (typeof indiciaData.filter.def.date_type !== 'undefined') {
-          dateType = indiciaData.filter.def.date_type;
-          if (dateType !== 'recorded') {
-            dateFromField = dateType + '_date_from';
-            dateToField = dateType + '_date_to';
-            dateAgeField = dateType + '_date_age';
-          }
-        }
-        if (indiciaData.filter.def[dateFromField] && indiciaData.filter.def[dateToField]) {
-          r.push('Records ' + dateType + ' between ' + indiciaData.filter.def[dateFromField] + ' and ' +
-            indiciaData.filter.def[dateToField]);
-        } else if (indiciaData.filter.def[dateFromField]) {
-          r.push('Records ' + dateType + ' on or after ' + indiciaData.filter.def[dateFromField]);
-        } else if (indiciaData.filter.def[dateToField]) {
-          r.push('Records ' + dateType + ' on or before ' + indiciaData.filter.def[dateToField]);
-        }
-        if (indiciaData.filter.def[dateAgeField]) {
-          r.push('Records ' + dateType + ' in last ' + indiciaData.filter.def[dateAgeField]);
-        }
-        return r.join('<br/>');
+        return indiciaData.filterParser.when.getDescription(indiciaData.filter.def, '<br/>');
+        // var r = [];
+        // var dateType = 'recorded';
+        // var dateFromField = 'date_from';
+        // var dateToField = 'date_to';
+        // var dateAgeField = 'date_age';
+        // if (typeof indiciaData.filter.def.date_type !== 'undefined') {
+        //   dateType = indiciaData.filter.def.date_type;
+        //   if (dateType !== 'recorded') {
+        //     dateFromField = dateType + '_date_from';
+        //     dateToField = dateType + '_date_to';
+        //     dateAgeField = dateType + '_date_age';
+        //   }
+        // }
+        // if (indiciaData.filter.def[dateFromField] && indiciaData.filter.def[dateToField]) {
+        //   r.push('Records ' + dateType + ' between ' + indiciaData.filter.def[dateFromField] + ' and ' +
+        //     indiciaData.filter.def[dateToField]);
+        // } else if (indiciaData.filter.def[dateFromField]) {
+        //   r.push('Records ' + dateType + ' on or after ' + indiciaData.filter.def[dateFromField]);
+        // } else if (indiciaData.filter.def[dateToField]) {
+        //   r.push('Records ' + dateType + ' on or before ' + indiciaData.filter.def[dateToField]);
+        // }
+        // if (indiciaData.filter.def[dateAgeField]) {
+        //   r.push('Records ' + dateType + ' in last ' + indiciaData.filter.def[dateAgeField]);
+        // }
+        // return r.join('<br/>');
       },
       loadForm: function (context) {
         var dateTypePrefix = '';
@@ -699,22 +702,23 @@ jQuery(document).ready(function ($) {
     },
     where: {
       getDescription: function () {
-        if (indiciaData.filter.def.remembered_location_name) {
-          return 'Records in ' + indiciaData.filter.def.remembered_location_name;
-        } else if (indiciaData.filter.def['imp-location:name']) { // legacy
-          return 'Records in ' + indiciaData.filter.def['imp-location:name'];
-        } else if (indiciaData.filter.def.indexed_location_id) {
-          // legacy location ID for the user's locality. In this case we need to hijack the site type drop down shortcuts to get the locality name
-          return $('#site-type option[value=loc\\:' + indiciaData.filter.def.indexed_location_id + ']').text();
-        } else if (indiciaData.filter.def.location_name) {
-          return 'Records in places containing "' + indiciaData.filter.def.location_name + '"';
-        } else if (indiciaData.filter.def.sref) {
-          return 'Records in square ' + indiciaData.filter.def.sref;
-        } else if (indiciaData.filter.def.searchArea) {
-          return 'Records within a freehand boundary';
-        } else {
-          return '';
-        }
+        return indiciaData.filterParser.where.getDescription(indiciaData.filter.def);
+        // if (indiciaData.filter.def.remembered_location_name) {
+        //   return 'Records in ' + indiciaData.filter.def.remembered_location_name;
+        // } else if (indiciaData.filter.def['imp-location:name']) { // legacy
+        //   return 'Records in ' + indiciaData.filter.def['imp-location:name'];
+        // } else if (indiciaData.filter.def.indexed_location_id) {
+        //   // legacy location ID for the user's locality. In this case we need to hijack the site type drop down shortcuts to get the locality name
+        //   return $('#site-type option[value=loc\\:' + indiciaData.filter.def.indexed_location_id + ']').text();
+        // } else if (indiciaData.filter.def.location_name) {
+        //   return 'Records in places containing "' + indiciaData.filter.def.location_name + '"';
+        // } else if (indiciaData.filter.def.sref) {
+        //   return 'Records in square ' + indiciaData.filter.def.sref;
+        // } else if (indiciaData.filter.def.searchArea) {
+        //   return 'Records within a freehand boundary';
+        // } else {
+        //   return '';
+        // }
       },
       applyFormToDefinition: function () {
         var geoms = [];
@@ -889,11 +893,12 @@ jQuery(document).ready(function ($) {
     },
     who: {
       getDescription: function () {
-        if (indiciaData.filter.def.my_records) {
-          return indiciaData.lang.reportFilters.MyRecords;
-        } else {
-          return '';
-        }
+        return indiciaData.filterParser.who.getDescription(indiciaData.filter.def);
+        // if (indiciaData.filter.def.my_records) {
+        //   return indiciaData.lang.reportFilters.MyRecords;
+        // } else {
+        //   return '';
+        // }
       },
       loadForm: function (context) {
         if (context && context.my_records) {
@@ -908,67 +913,70 @@ jQuery(document).ready(function ($) {
     },
     occ_id: {
       getDescription: function () {
-        var op;
-        if (indiciaData.filter.def.occ_id) {
-          op = typeof indiciaData.filter.def.occ_id_op === 'undefined' ?
-            '=' : indiciaData.filter.def.occ_id_op.replace(/[<=>]/g, '\\$&');
-          return $('#occ_id_op').find("option[value='" + op + "']").html()
-            + ' ' + indiciaData.filter.def.occ_id;
-        }
-        else if (indiciaData.filter.def.occurrence_external_key) {
-          return $('#ctrl-wrap-occurrence_external_key label').html().replace(/:$/, '')
-            + ' ' + indiciaData.filter.def.occurrence_external_key;
-        }
-        return '';
+        return indiciaData.filterParser.occ_id.getDescription(indiciaData.filter.def);
+        // var op;
+        // if (indiciaData.filter.def.occ_id) {
+        //   op = typeof indiciaData.filter.def.occ_id_op === 'undefined' ?
+        //     '=' : indiciaData.filter.def.occ_id_op.replace(/[<=>]/g, '\\$&');
+        //   return $('#occ_id_op').find("option[value='" + op + "']").html()
+        //     + ' ' + indiciaData.filter.def.occ_id;
+        // }
+        // else if (indiciaData.filter.def.occurrence_external_key) {
+        //   return $('#ctrl-wrap-occurrence_external_key label').html().replace(/:$/, '')
+        //     + ' ' + indiciaData.filter.def.occurrence_external_key;
+        // }
+        // return '';
       },
       loadForm: function () {
       }
     },
     smp_id: {
       getDescription: function () {
-        var op;
-        if (indiciaData.filter.def.smp_id) {
-          op = typeof indiciaData.filter.def.smp_id === 'undefined' ? '=' : indiciaData.filter.def.smp_id.replace(/[<=>]/g, "\\$&");
-          return $('#smp_id_op option[value=' + op + ']').html()
-            + ' ' + indiciaData.filter.def.smp_id;
-        }
-        return '';
+        return indiciaData.filterParser.smp_id.getDescription(indiciaData.filter.def);
+        // var op;
+        // if (indiciaData.filter.def.smp_id) {
+        //   op = typeof indiciaData.filter.def.smp_id === 'undefined' ? '=' : indiciaData.filter.def.smp_id.replace(/[<=>]/g, "\\$&");
+        //   return $('#smp_id_op option[value=' + op + ']').html()
+        //     + ' ' + indiciaData.filter.def.smp_id;
+        // }
+        // return '';
       },
       loadForm: function () {
       }
     },
     quality: {
       getDescription: function () {
-        var r = [];
-        var op;
-        var quality;
-        if (typeof indiciaData.filter.def.quality === 'undefined') {
-          quality = 'all';
-        } else {
-          quality = typeof indiciaData.filter.def.quality === 'string'
-            ? indiciaData.filter.def.quality : indiciaData.filter.def.quality.toString();
-        }
-        if (quality !== 'all') {
-          r.push($('#quality-filter option[value=' + quality.replace('!', '\\!') + ']').html());
-        }
-        if (indiciaData.filter.def.autochecks === 'F') {
-          r.push(indiciaData.lang.reportFilters.AutochecksFailed);
-        } else if (indiciaData.filter.def.autochecks === 'P') {
-          r.push(indiciaData.lang.reportFilters.AutochecksPassed);
-        }
-        if (indiciaData.filter.def.identification_difficulty) {
-          op = typeof indiciaData.filter.def.identification_difficulty_op === 'undefined' ?
-            '=' : indiciaData.filter.def.identification_difficulty_op.replace(/[<=>]/g, '\\$&');
-          r.push(indiciaData.lang.reportFilters.IdentificationDifficulty + ' ' +
-            $('#identification_difficulty_op').find("option[value='" + op + "']").html() +
-            ' ' + indiciaData.filter.def.identification_difficulty);
-        }
-        if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '1') {
-          r.push(indiciaData.lang.reportFilters.HasPhotos);
-        } else if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '0') {
-          r.push(indiciaData.lang.reportFilters.HasNoPhotos);
-        }
-        return r.join('<br/>');
+        return indiciaData.filterParser.quality.getDescription(indiciaData.filter.def, '<br/>');
+        // var r = [];
+        // var op;
+        // var quality;
+        // if (typeof indiciaData.filter.def.quality === 'undefined') {
+        //   quality = 'all';
+        // } else {
+        //   quality = typeof indiciaData.filter.def.quality === 'string'
+        //     ? indiciaData.filter.def.quality : indiciaData.filter.def.quality.toString();
+        // }
+        // if (quality !== 'all') {
+        //   r.push($('#quality-filter option[value=' + quality.replace('!', '\\!') + ']').html());
+        // }
+        // if (indiciaData.filter.def.autochecks === 'F') {
+        //   r.push(indiciaData.lang.reportFilters.AutochecksFailed);
+        // } else if (indiciaData.filter.def.autochecks === 'P') {
+        //   r.push(indiciaData.lang.reportFilters.AutochecksPassed);
+        // }
+        // if (indiciaData.filter.def.identification_difficulty) {
+        //   op = typeof indiciaData.filter.def.identification_difficulty_op === 'undefined' ?
+        //     '=' : indiciaData.filter.def.identification_difficulty_op.replace(/[<=>]/g, '\\$&');
+        //   r.push(indiciaData.lang.reportFilters.IdentificationDifficulty + ' ' +
+        //     $('#identification_difficulty_op').find("option[value='" + op + "']").html() +
+        //     ' ' + indiciaData.filter.def.identification_difficulty);
+        // }
+        // if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '1') {
+        //   r.push(indiciaData.lang.reportFilters.HasPhotos);
+        // } else if (indiciaData.filter.def.has_photos && indiciaData.filter.def.has_photos === '0') {
+        //   r.push(indiciaData.lang.reportFilters.HasNoPhotos);
+        // }
+        // return r.join('<br/>');
       },
       loadForm: function (context) {
         if (context && context.quality && context.quality !== 'all') {
@@ -1001,30 +1009,31 @@ jQuery(document).ready(function ($) {
     },
     source: {
       getDescription: function () {
-        var r = [];
-        var list = [];
-        var paramValue;
-        if (indiciaData.filter.def.input_form_list) {
-          $.each(indiciaData.filter.def.input_form_list.split(','), function (idx, id) {
-            list.push($('#check-form-' + indiciaData.formsList[id.replace(/'/g, '')]).next('label').html());
-          });
-          r.push((indiciaData.filter.def.input_form_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        } else if (indiciaData.filter.def.survey_list) {
-          paramValue = typeof indiciaData.filter.def.survey_list === 'string'
-            ? indiciaData.filter.def.survey_list.split(',') : [indiciaData.filter.def.survey_list ];
-          $.each(paramValue, function (idx, id) {
-            list.push($('#check-survey-' + id).next('label').html());
-          });
-          r.push((indiciaData.filter.def.survey_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        } else if (indiciaData.filter.def.website_list) {
-          paramValue = typeof indiciaData.filter.def.website_list === 'string'
-            ? indiciaData.filter.def.website_list.split(',') : [indiciaData.filter.def.survey_list ];
-          $.each(indiciaData.filter.def.website_list.toString().split(','), function (idx, id) {
-            list.push($('#check-website-' + id).next('label').html());
-          });
-          r.push((indiciaData.filter.def.website_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
-        }
-        return r.join('<br/>');
+        return indiciaData.filterParser.source.getDescription(indiciaData.filter.def, '<br/>');
+        // var r = [];
+        // var list = [];
+        // var paramValue;
+        // if (indiciaData.filter.def.input_form_list) {
+        //   $.each(indiciaData.filter.def.input_form_list.split(','), function (idx, id) {
+        //     list.push($('#check-form-' + indiciaData.formsList[id.replace(/'/g, '')]).next('label').html());
+        //   });
+        //   r.push((indiciaData.filter.def.input_form_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
+        // } else if (indiciaData.filter.def.survey_list) {
+        //   paramValue = typeof indiciaData.filter.def.survey_list === 'string'
+        //     ? indiciaData.filter.def.survey_list.split(',') : [indiciaData.filter.def.survey_list ];
+        //   $.each(paramValue, function (idx, id) {
+        //     list.push($('#check-survey-' + id).next('label').html());
+        //   });
+        //   r.push((indiciaData.filter.def.survey_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
+        // } else if (indiciaData.filter.def.website_list) {
+        //   paramValue = typeof indiciaData.filter.def.website_list === 'string'
+        //     ? indiciaData.filter.def.website_list.split(',') : [indiciaData.filter.def.survey_list ];
+        //   $.each(indiciaData.filter.def.website_list.toString().split(','), function (idx, id) {
+        //     list.push($('#check-website-' + id).next('label').html());
+        //   });
+        //   r.push((indiciaData.filter.def.website_list_op === 'not in' ? 'Exclude ' : '') + list.join(', '));
+        // }
+        // return r.join('<br/>');
       },
       loadForm: function (context) {
         if (context && ((context.website_list && context.website_list_op) ||


### PR DESCRIPTION
This is to create a new [filterSummary] control to address point 4 here: BiologicalRecordsCentre/iRecord#800 (comment). It is implemented through a new jquery plugin. The control needs to parse existing filters. Code to do this is already present in reportFilters.js for the standard parameters filter control. To make this code accessible to this plugin, I've suggested delegating some of the necessary reporting code in the paneObjList object to a gloal object - indiciaData.filterParser. Is this approach okay?

Note that the control also deals with the statusFilter control, though this isn't included in this branch - it is the subject of another branch.