### PR TITLE
Fixes bug in download paging when template dropdown used

### DIFF
--- a/js/indicia.datacomponents/jquery.idc.esDownload.js
+++ b/js/indicia.datacomponents/jquery.idc.esDownload.js
@@ -111,7 +111,11 @@
     var sourceSettings = el.settings.sourceObject.settings;
     var isAggregation = el.settings.sourceObject.settings.mode.match(/Aggregation$/);
     // Note, columnsTemplate can be blank.
-    if (typeof el.settings.columnsTemplate !== 'undefined') {
+    if ($('#' + el.id + '-template').val()) {
+      // If there is an associated download template select control,
+      // set the columns template from its value.
+      data.columnsTemplate = $('#' + el.id + '-template').val();
+    } else if (typeof el.settings.columnsTemplate !== 'undefined') {
       data.columnsTemplate = el.settings.columnsTemplate;
     } else if (isAggregation) {
       // Aggregations default to no columns template.
@@ -296,11 +300,6 @@
       $.extend(currentRequestData, columnSettings);
       // Reset.
       rowsToDownload = null;
-      // If there is an associated download template select control,
-      // set the download template option from its value.
-      if ($('#' + el.id + '-template').val()) {
-        currentRequestData['columnsTemplate'] = $('#' + el.id + '-template').val();
-      }
       // Post to the ES proxy.
       $.ajax({
         url: indiciaData.esProxyAjaxUrl + '/download/' + indiciaData.nid + query,


### PR DESCRIPTION
When columns template selected from the new download format
drop-down control, tempalte was not preserved across paging of
large datasets.