### PR TITLE
Iss 955

### DIFF
--- a/js/indicia.datacomponents/jquery.idc.leafletMap.js
+++ b/js/indicia.datacomponents/jquery.idc.leafletMap.js
@@ -390,14 +390,20 @@
    */
   function layerEnabled(el, id, layerConfig) {
     var layerState;
-    if (el.settings.layerState) {
+    if (el.settings.layerState && !layerConfig.forceEnabled) {
       layerState = JSON.parse(el.settings.layerState);
       if (layerState[id]) {
         return layerState[id].enabled;
       }
     }
     // Revert to default in layer config.
-    return typeof layerConfig.enabled === 'undefined' ? true : layerConfig.enabled;
+    if (layerConfig.enabled === 'undefined') {
+      return true
+    } else if (layerConfig.forceEnabled) {
+      return true
+    } else {
+      return layerConfig.enabled
+    }
   }
 
   /**

--- a/js/indicia.datacomponents/jquery.idc.leafletMap.js
+++ b/js/indicia.datacomponents/jquery.idc.leafletMap.js
@@ -398,11 +398,11 @@
     }
     // Revert to default in layer config.
     if (layerConfig.forceEnabled) {
-      return true
+      return true;
     } else if (layerConfig.enabled === 'undefined') {
-      return true
+      return true;
     } else {
-      return layerConfig.enabled
+      return layerConfig.enabled;
     }
   }
 

--- a/js/indicia.datacomponents/jquery.idc.leafletMap.js
+++ b/js/indicia.datacomponents/jquery.idc.leafletMap.js
@@ -397,9 +397,9 @@
       }
     }
     // Revert to default in layer config.
-    if (layerConfig.enabled === 'undefined') {
+    if (layerConfig.forceEnabled) {
       return true
-    } else if (layerConfig.forceEnabled) {
+    } else if (layerConfig.enabled === 'undefined') {
       return true
     } else {
       return layerConfig.enabled


### PR DESCRIPTION
For issue https://github.com/BiologicalRecordsCentre/iRecord/issues/955. If the 'forceEnabled' attribute is set on a map layer configuration, then that layer will be enabled when a page is first loaded regardless of the last enabled state set by the user on that page when last used (and stored in cookie). If you are happy with this John, I will document.