### PR TITLE
 To support new species details form hotfeature

### DIFF
--- a/js/indicia.datacomponents/jquery.idc.leafletMap.js
+++ b/js/indicia.datacomponents/jquery.idc.leafletMap.js
@@ -861,6 +861,15 @@
       });
       return needsPopulation;
       // @todo Disable layer if source linked to grid and no row selected.
+    },
+
+    /**
+     * Exposes the leaflet invalidateSize method which can be used to force
+     * a map repaint - especially valuable if the map is initialised when
+     * not visible. In that case, call the method once the map is made visible.
+     */
+    invalidateSize: function invalidateSize() {
+      this.map.invalidateSize();
     }
   };
 


### PR DESCRIPTION
Added method to expose leaflet invalidateSize method which can be required by new controls available on new species details form.